### PR TITLE
Handle the NOPs once again

### DIFF
--- a/src/cg_vm.c
+++ b/src/cg_vm.c
@@ -100,6 +100,7 @@ static void VM_Run(vm_t* vm)
     case OP_NOP:
     // break to debugger?
     case OP_BREAK:
+      break;
     // anything else
     default:
       trap_Error(vaf("ERROR: VM_Run: Unhandled opcode(%i)", op));


### PR DESCRIPTION
Regressed in https://github.com/Jelvan1/cgame-proxymod/commit/88680067ed0f986cc51d2e287f5734412136ce1b#diff-843202b6a1028d9c4b93c95b4a80cffaafced02b5250d288f58a7f79b67e3b7eR81-R89

The original quake3.exe actually implicitly handled the opcodes[1] by just falling through to another iteration of the `while(1)` as no one defines `DEBUG_VM`[2][3]. Moreover engines like Quake3e explicitly handle the opcodes (well `OP_NOP/IGNORE` and `OP_BREAK`, I guess `OP_UNDEF` would error in q3e)[4].

[1] https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/qcommon/vm_interpreted.c#L411-L414
[2] https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/qcommon/vm_interpreted.c#L309
[3] https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/qcommon/vm_ppc_new.c#L29
[4] https://github.com/ec-/Quake3e/blob/fe57ee907f4b858a09c6b64348f08750b2b469a2/code/qcommon/vm_interpreted.c#L214-L220